### PR TITLE
Add compatibility across OS

### DIFF
--- a/R/polyOriginR.R
+++ b/R/polyOriginR.R
@@ -3,7 +3,7 @@
 #' @description Haplotype reconstruction in polyploid multiparental populations
 #' @param genofile Input genotypic data for parents and offspring
 #' @param pedfile Input breeding pedigree
-#' @param julia_home Path to julia.exe, Default: ''
+#' @param julia_path Path to julia, Default: ''
 #' @param epsilon genotyping error probability, Default: 0.01
 #' @param seqerr sequencing read error probability for GBS data, Default: 0.001
 #' @param chrpairing_phase chromosome pairing in parental phasing, with 22 being only bivalent formations and 44 being bi- and quadri-valent formations, Default: 22
@@ -46,7 +46,7 @@
 #' }
 #' @rdname polyOriginR
 #' @export 
-polyOriginR <- function(genofile,pedfile,julia_home = "",
+polyOriginR <- function(genofile,pedfile,juliapath = "",
               epsilon=0.01, seqerr=0.001,
               chrpairing_phase=22, chrpairing=44, 
               chrsubset=NULL,snpthin=1,
@@ -59,11 +59,12 @@ polyOriginR <- function(genofile,pedfile,julia_home = "",
               stripdis=20, maxepsilon=0.5,skeletonsize=50,
               isphysmap = FALSE, recomrate = 1.0,
               workdir=getwd(),outstem = "outstem",verbose = TRUE){
+  
+  ## Getting OS
   genofile2 = if (dirname(genofile) == ".") file.path(workdir,genofile) else normalizePath(genofile)
   pedfile2 = if (dirname(pedfile) == ".") file.path(workdir,pedfile) else normalizePath(pedfile)
-  juliaexe <- file.path(julia_home,"julia.exe")
   mainfile <- file.path(path.package("PolyOriginR"),"bin","polyOrigin_main.jl")
-  # juliaexe <- paste0("\"",juliaexe,"\""); resulting in errors
+  juliaexe <- paste0("\"",juliapath,"\"")
   mainfile <- paste0("\"",mainfile,"\"")
   genofile2 <- paste0("\"",genofile2,"\"")
   pedfile2 <- paste0("\"",pedfile2,"\"")
@@ -92,8 +93,8 @@ polyOriginR <- function(genofile,pedfile,julia_home = "",
     "--isphysmap",isphysmap2,"--recomrate",recomrate2,
     "-w",workdir2,"-o",outstem,"-v",verbose2)
   cmdstr <- paste(juliaexe, mainfile,"-g",genofile2,"-p",pedfile2, opt)
-  shell(cmdstr)
+  system(cmdstr)
   logfile <-file.path(workdir,paste0(outstem,".log"))
   cat("Assembled command line: ",cmdstr,file=logfile,sep="\n",append=TRUE)
-  return(0)
+  return()
 }

--- a/inst/example/run_polyOriginR.R
+++ b/inst/example/run_polyOriginR.R
@@ -3,5 +3,10 @@ workdir <- file.path(path.package("PolyOriginR"),"example")
 genofile <- "geno.csv"
 pedfile <- "ped.csv"
 
-julia_home <- "C:/Users/username/AppData/Local/Programs/Julia/Julia-1.4.1/bin"
-polyOriginR(genofile,pedfile,julia_home=julia_home,workdir=workdir)
+## If Windows julia.exe path
+juliapath <- "C:/Users/username/AppData/Local/Programs/Julia/Julia-1.4.1/bin/julia.exe"
+
+## If Linux/Mac julia path
+juliapath <- "/home/username/Julia/Julia-1.4.1/bin/julia"
+
+polyOriginR(genofile,pedfile,juliapath=juliapath,workdir=workdir)

--- a/man/polyOriginR.Rd
+++ b/man/polyOriginR.Rd
@@ -7,7 +7,7 @@
 polyOriginR(
   genofile,
   pedfile,
-  julia_home = "",
+  juliapath = "",
   epsilon = 0.01,
   seqerr = 0.001,
   chrpairing_phase = 22,
@@ -42,8 +42,6 @@ polyOriginR(
 \item{genofile}{Input genotypic data for parents and offspring}
 
 \item{pedfile}{Input breeding pedigree}
-
-\item{julia_home}{Path to julia.exe, Default: ''}
 
 \item{epsilon}{genotyping error probability, Default: 0.01}
 
@@ -100,6 +98,8 @@ polyOriginR(
 \item{outstem}{Stem of output files, Default: 'outstem'}
 
 \item{verbose}{TURE, if print details, Default: TRUE}
+
+\item{julia_path}{Path to julia, Default: ''}
 }
 \value{
 Return 0 if sucess, and save four output files:


### PR DESCRIPTION
Instead of the path to the bin folder, now it is using the complete julia.exe path (or just julia file in linux/mac). I change shell to system, the later is compatible across OS.
I evaluated under Linux and Windows, for Mac should be OK since it uses same syntax as Linux. 
